### PR TITLE
[ci] benchmark tests run only on manual trigger

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,5 @@
 name: Benchmark Acceptance Test
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches: [main]
   workflow_dispatch:
 jobs:
   bench-test:


### PR DESCRIPTION
Remove pull_request trigger to prevent unstable benchmark tests from running on each push. Keep workflow_dispatch for manual execution.
